### PR TITLE
fix: add smooth closing animation to desktop drawer

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -111,7 +111,7 @@ export default function Sidebar({
       sx={{
         width: { md: desktopOpen ? drawerWidth : 0 },
         flexShrink: 0,
-        transition: 'width 225ms cubic-bezier(0.4, 0, 0.6, 1)',
+        transition: theme.transitions.create('width', { easing: theme.transitions.easing.sharp, duration: theme.transitions.duration.leavingScreen
       }}
     >
       <Drawer


### PR DESCRIPTION
## Summary
- Add `transition: width 225ms cubic-bezier(0.4, 0, 0.6, 1)` to both the nav container and drawer paper
- Uses MUI's standard easing curve for consistency
- Drawer now animates smoothly when both opening AND closing

## Test plan
- [ ] Open sidebar → smooth animation
- [ ] Close sidebar → smooth animation (was instant before)
- [ ] Mobile drawer unaffected (uses temporary variant)

Closes #14